### PR TITLE
Allow bare function keys (F1-F12) as shortcuts without requiring a modifier

### DIFF
--- a/src/components/ShortcutInput.tsx
+++ b/src/components/ShortcutInput.tsx
@@ -6,9 +6,10 @@ import {
   type KeyboardEvent,
 } from 'react';
 
-import { metaKeyPattern, isFunctionKey } from '@src/constants.js';
+import { metaKeyPattern } from '@src/constants.js';
 import { getShortcutFromEvent } from '@utils/getShortcutFromEvent.js';
 import { hasModifier } from '@utils/hasModifier.js';
+import { isFunctionKey } from '@utils/type-predicate.js';
 import type { Shortcut } from '@models/shortcut.js';
 
 export interface ShortcutInputProps extends InputHTMLAttributes<HTMLInputElement> {

--- a/src/components/ShortcutInput.tsx
+++ b/src/components/ShortcutInput.tsx
@@ -6,7 +6,7 @@ import {
   type KeyboardEvent,
 } from 'react';
 
-import { metaKeyPattern } from '@src/constants.js';
+import { metaKeyPattern, isFunctionKey } from '@src/constants.js';
 import { getShortcutFromEvent } from '@utils/getShortcutFromEvent.js';
 import { hasModifier } from '@utils/hasModifier.js';
 import type { Shortcut } from '@models/shortcut.js';
@@ -32,8 +32,9 @@ export const ShortcutInput: FunctionComponent<ShortcutInputProps> = ({
         return;
       }
 
-      // Only set the shortcut if a non-modifier key is pressed along with at least one modifier key
-      if (!metaKeyPattern.test(event.key) && hasModifierKey) {
+      // Only set the shortcut if a non-modifier key is pressed along with at least one modifier key,
+      // or if a function key (F1-F12) is pressed (modifiers optional)
+      if (!metaKeyPattern.test(event.key) && (hasModifierKey || isFunctionKey(event.key))) {
         setShortcut(getShortcutFromEvent(event));
       }
 

--- a/src/components/ShortcutList/ShortcutList.tsx
+++ b/src/components/ShortcutList/ShortcutList.tsx
@@ -1,8 +1,8 @@
 import { capitalize } from '@webdeveric/utils/capitalize';
 import classnames from 'classnames';
 
-import { isFunctionKey } from '@src/constants.js';
 import { formatShortcut } from '@utils/formatShortcut.js';
+import { isFunctionKey } from '@utils/type-predicate.js';
 import type { Shortcut } from '@models/shortcut.js';
 
 import * as styles from './ShortcutList.css';

--- a/src/components/ShortcutList/ShortcutList.tsx
+++ b/src/components/ShortcutList/ShortcutList.tsx
@@ -1,6 +1,7 @@
 import { capitalize } from '@webdeveric/utils/capitalize';
 import classnames from 'classnames';
 
+import { isFunctionKey } from '@src/constants.js';
 import { formatShortcut } from '@utils/formatShortcut.js';
 import type { Shortcut } from '@models/shortcut.js';
 
@@ -21,7 +22,8 @@ const Shortcut: FunctionComponent<{ className?: string; shortcut: Shortcut }> = 
   return (
     <span className={className}>
       {mods}
-      <kbd>{key === ' ' ? 'space' : key}</kbd>
+      {/* Function keys are stored lowercased but should display as e.g. "F1" */}
+      <kbd>{key === ' ' ? 'space' : isFunctionKey(key) ? key.toUpperCase() : key}</kbd>
       {selector && <code className={styles.selector}>{selector}</code>}
     </span>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,7 @@
 export const metaKeyPattern = /^(Alt|Control|Meta|Shift)(Left|Right)?$/;
+
+// Matches F1-F12 (case-insensitive because keys are stored lowercased via getShortcutFromEvent,
+// but arrive uppercase from KeyboardEvent.key in the browser).
+export const functionKeyPattern = /^F([1-9]|1[0-2])$/i;
+
+export const isFunctionKey = (key: string): boolean => functionKeyPattern.test(key);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,1 @@
 export const metaKeyPattern = /^(Alt|Control|Meta|Shift)(Left|Right)?$/;
-
-// Matches F1-F12 (case-insensitive because keys are stored lowercased via getShortcutFromEvent,
-// but arrive uppercase from KeyboardEvent.key in the browser).
-export const functionKeyPattern = /^F([1-9]|1[0-2])$/i;
-
-export const isFunctionKey = (key: string): boolean => functionKeyPattern.test(key);

--- a/src/models/shortcut.ts
+++ b/src/models/shortcut.ts
@@ -1,7 +1,10 @@
-import type { RequireAtLeastOne } from '@webdeveric/utils/types/records';
 import type { Pretty } from '@webdeveric/utils/types/utils';
 
-export type MetaKeys = RequireAtLeastOne<Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>>;
+// Modifier keys are all optional (not RequireAtLeastOne) so that bare function keys
+// like F1 can be represented as shortcuts without any modifier. The business rule
+// "must have a modifier OR be a function key" is enforced at runtime by isShortcut
+// in type-predicate.ts and at the UI level in ShortcutInput.tsx.
+export type MetaKeys = Partial<Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>>;
 
 export type ShortcutKey = Pick<KeyboardEvent, 'key'>;
 

--- a/src/utils/createShortcutWithDefaults.test.ts
+++ b/src/utils/createShortcutWithDefaults.test.ts
@@ -15,4 +15,17 @@ describe('createShortcutWithDefaults', () => {
       key: 'k',
     });
   });
+
+  it('returns a Shortcut for a bare function key', () => {
+    const shortcut = createShortcutWithDefaults({ key: 'f1' });
+
+    expect(shortcut).toMatchObject({
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      selector: undefined,
+      key: 'f1',
+    });
+  });
 });

--- a/src/utils/eventIsShortcut.test.ts
+++ b/src/utils/eventIsShortcut.test.ts
@@ -31,6 +31,22 @@ describe('eventIsShortcut', () => {
     expect(eventIsShortcut(event, shortcut)).toBe(false);
   });
 
+  it('matches a bare function key shortcut', () => {
+    const f1Shortcut: Shortcut = { key: 'f1' };
+
+    const matchingEvent = new KeyboardEvent('keydown', { key: 'F1' });
+
+    expect(eventIsShortcut(matchingEvent, f1Shortcut)).toBe(true);
+
+    const nonMatchingEvent = new KeyboardEvent('keydown', { key: 'F2' });
+
+    expect(eventIsShortcut(nonMatchingEvent, f1Shortcut)).toBe(false);
+
+    const withModifierEvent = new KeyboardEvent('keydown', { key: 'F1', ctrlKey: true });
+
+    expect(eventIsShortcut(withModifierEvent, f1Shortcut)).toBe(false);
+  });
+
   it('checks selector', () => {
     const event = {
       altKey: false,

--- a/src/utils/formatShortcut.test.ts
+++ b/src/utils/formatShortcut.test.ts
@@ -24,4 +24,13 @@ describe('formatShortcut', () => {
       'Ctrl + k on body',
     );
   });
+
+  it('displays function keys in uppercase', () => {
+    expect(formatShortcut(createShortcutWithDefaults({ key: 'f1' }))).toEqual('F1');
+    expect(formatShortcut(createShortcutWithDefaults({ key: 'f12' }))).toEqual('F12');
+  });
+
+  it('displays function keys with modifiers in uppercase', () => {
+    expect(formatShortcut(createShortcutWithDefaults({ ctrlKey: true, key: 'f5' }))).toEqual('Ctrl + F5');
+  });
 });

--- a/src/utils/formatShortcut.ts
+++ b/src/utils/formatShortcut.ts
@@ -2,6 +2,8 @@ import { capitalize } from '@webdeveric/utils/capitalize';
 
 import type { Shortcut } from '@models/shortcut.js';
 
+import { isFunctionKey } from '../constants.js';
+
 export const formatShortcut = (shortcut?: Shortcut): string => {
   if (!shortcut) {
     return '';
@@ -14,5 +16,9 @@ export const formatShortcut = (shortcut?: Shortcut): string => {
     .map(([modifierKey]) => capitalize(modifierKey.replace(/Key$/, '')))
     .join(' + ');
 
-  return `${mod ? `${mod} + ` : ''}${key}${selector ? ` on ${selector}` : ''}`;
+  // Function keys are stored lowercased (e.g. "f1") by getShortcutFromEvent,
+  // but should display in their conventional uppercase form (e.g. "F1").
+  const displayKey = isFunctionKey(key) ? key.toUpperCase() : key;
+
+  return `${mod ? `${mod} + ` : ''}${displayKey}${selector ? ` on ${selector}` : ''}`;
 };

--- a/src/utils/formatShortcut.ts
+++ b/src/utils/formatShortcut.ts
@@ -2,7 +2,7 @@ import { capitalize } from '@webdeveric/utils/capitalize';
 
 import type { Shortcut } from '@models/shortcut.js';
 
-import { isFunctionKey } from '../constants.js';
+import { isFunctionKey } from './type-predicate.js';
 
 export const formatShortcut = (shortcut?: Shortcut): string => {
   if (!shortcut) {

--- a/src/utils/getShortcutFromEvent.test.ts
+++ b/src/utils/getShortcutFromEvent.test.ts
@@ -19,4 +19,20 @@ describe('getShortcutFromEvent', () => {
       key: 'k',
     });
   });
+
+  it('lowercases function key names', () => {
+    const event = new KeyboardEvent('keydown', {
+      key: 'F1',
+    });
+
+    const shortcut = getShortcutFromEvent(event);
+
+    expect(shortcut).toMatchObject({
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      key: 'f1',
+    });
+  });
 });

--- a/src/utils/type-predicate.test.ts
+++ b/src/utils/type-predicate.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { isShortcut, isShortcutArray } from './type-predicate.js';
+
+describe('isShortcut', () => {
+  it('returns true for a shortcut with a modifier key', () => {
+    expect(isShortcut({ key: 'k', ctrlKey: true })).toBe(true);
+    expect(isShortcut({ key: 'l', metaKey: true })).toBe(true);
+    expect(isShortcut({ key: 'a', altKey: true, shiftKey: false })).toBe(true);
+  });
+
+  it('returns false for a shortcut without a modifier key or function key', () => {
+    expect(isShortcut({ key: 'k' })).toBe(false);
+    expect(isShortcut({ key: 'a' })).toBe(false);
+  });
+
+  it('returns true for a bare function key (F1-F12)', () => {
+    expect(isShortcut({ key: 'f1' })).toBe(true);
+    expect(isShortcut({ key: 'f12' })).toBe(true);
+    expect(isShortcut({ key: 'F1' })).toBe(true);
+    expect(isShortcut({ key: 'F12' })).toBe(true);
+  });
+
+  it('returns true for a function key with modifiers', () => {
+    expect(isShortcut({ key: 'f1', ctrlKey: true })).toBe(true);
+    expect(isShortcut({ key: 'f5', altKey: true, shiftKey: false })).toBe(true);
+  });
+
+  it('returns false for invalid function key values', () => {
+    expect(isShortcut({ key: 'f0' })).toBe(false);
+    expect(isShortcut({ key: 'f13' })).toBe(false);
+    expect(isShortcut({ key: 'f123' })).toBe(false);
+  });
+
+  it('returns false for non-shortcut values', () => {
+    expect(isShortcut(null)).toBe(false);
+    expect(isShortcut(undefined)).toBe(false);
+    expect(isShortcut('string')).toBe(false);
+    expect(isShortcut(42)).toBe(false);
+    expect(isShortcut({})).toBe(false);
+    expect(isShortcut({ key: 123 })).toBe(false);
+  });
+});
+
+describe('isShortcutArray', () => {
+  it('returns true for an array of valid shortcuts', () => {
+    expect(isShortcutArray([{ key: 'k', ctrlKey: true }, { key: 'f1' }])).toBe(true);
+  });
+
+  it('returns false if any item is invalid', () => {
+    expect(isShortcutArray([{ key: 'k', ctrlKey: true }, { key: 'a' }])).toBe(false);
+  });
+
+  it('returns true for an empty array', () => {
+    expect(isShortcutArray([])).toBe(true);
+  });
+});

--- a/src/utils/type-predicate.ts
+++ b/src/utils/type-predicate.ts
@@ -7,6 +7,27 @@ import { isOptionalBoolean } from '@webdeveric/utils/predicate/isOptionalBoolean
 import { isOptionalString } from '@webdeveric/utils/predicate/isOptionalString';
 import { isString } from '@webdeveric/utils/predicate/isString';
 
+import { isFunctionKey } from '../constants.js';
+
+// Allows bare function keys (F1-F12) to pass validation without any modifier key.
+// This is needed because isFunctionKey checks the stored key value, which is lowercased.
+const hasFunctionKey = (value: unknown): value is { key: string } =>
+  typeof value === 'object' &&
+  value !== null &&
+  'key' in value &&
+  typeof value.key === 'string' &&
+  isFunctionKey(value.key);
+
+const hasModifierKey = anyOf(
+  shape({ altKey: isBoolean }),
+  shape({ ctrlKey: isBoolean }),
+  shape({ metaKey: isBoolean }),
+  shape({ shiftKey: isBoolean }),
+);
+
+// A valid shortcut must have either at least one modifier key (Ctrl, Alt, etc.)
+// OR be a function key (F1-F12). This prevents bare letter keys like "a" from
+// being registered as shortcuts, which would break typing on every website.
 export const isShortcut = allOf(
   shape({
     key: isString,
@@ -16,12 +37,7 @@ export const isShortcut = allOf(
     metaKey: isOptionalBoolean,
     shiftKey: isOptionalBoolean,
   }),
-  anyOf(
-    shape({ altKey: isBoolean }),
-    shape({ ctrlKey: isBoolean }),
-    shape({ metaKey: isBoolean }),
-    shape({ shiftKey: isBoolean }),
-  ),
+  anyOf(hasModifierKey, hasFunctionKey),
 );
 
 export const isShortcutArray = everyItem(isShortcut);

--- a/src/utils/type-predicate.ts
+++ b/src/utils/type-predicate.ts
@@ -7,16 +7,17 @@ import { isOptionalBoolean } from '@webdeveric/utils/predicate/isOptionalBoolean
 import { isOptionalString } from '@webdeveric/utils/predicate/isOptionalString';
 import { isString } from '@webdeveric/utils/predicate/isString';
 
-import { isFunctionKey } from '../constants.js';
+// Matches F1-F12 (case-insensitive because keys are stored lowercased via getShortcutFromEvent,
+// but arrive uppercase from KeyboardEvent.key in the browser).
+const functionKeyPattern = /^F([1-9]|1[0-2])$/i;
+
+export const isFunctionKey = (value: unknown): value is string =>
+  typeof value === 'string' && functionKeyPattern.test(value);
 
 // Allows bare function keys (F1-F12) to pass validation without any modifier key.
-// This is needed because isFunctionKey checks the stored key value, which is lowercased.
-const hasFunctionKey = (value: unknown): value is { key: string } =>
-  typeof value === 'object' &&
-  value !== null &&
-  'key' in value &&
-  typeof value.key === 'string' &&
-  isFunctionKey(value.key);
+const hasFunctionKey = shape({
+  key: isFunctionKey,
+});
 
 const hasModifierKey = anyOf(
   shape({ altKey: isBoolean }),


### PR DESCRIPTION
Fixes #16

Thanks to `pnpm start`, this was really easy to test this for me!

- <kbd>F1</kbd> is accepted in the field
  <img width="240" height="360" alt="image" src="https://github.com/user-attachments/assets/725f1a8e-db85-43ff-b1e7-71793ae4e55b" />
- Can be added to the list
  <img width="120" height="786" alt="image" src="https://github.com/user-attachments/assets/7181da5f-5a4f-4509-bc33-25bfbcdee634" />

I then logged into linear.app and it worked just as expected.

Also tested some other sites and testing existing CMD-k, saw no issues 🤞🏼 

Thanks for this great extension 🙇🏼 